### PR TITLE
Psj sokolov add oude statuten

### DIFF
--- a/statuten.txt
+++ b/statuten.txt
@@ -1,43 +1,43 @@
-Holtman notarissen - 1 -
+ Holtman notarissen - 1 -
 
 865454 /me
 21-07-2017
 
           STATUTENWIJZIGING VERENIGING
 
-Heden, een en twintig juli tweeduizend zeventien, ------------------
-verscheen voor mij, mr. Madeline Elisabeth Westers-Koopmans, -------
-kandidaat-notaris, hierna te noemen "notaris", vaste waarnemer van -
-mr. Ritzo Jacob Holtman, notaris te Utrecht: ----------------------
+Heden, een en twintig juli tweeduizend zeventien,
+verscheen voor mij, mr. Madeline Elisabeth Westers-Koopmans,
+kandidaat-notaris, hierna te noemen "notaris", vaste waarnemer van
+mr. Ritzo Jacob Holtman, notaris te Utrecht:
 mevrouw Samantha Subadra de Jong, geboren te Ratnapura op twee
-oktober negentienhonderdvierentachtig, met kantooradres 3583 GP    -
-Utrecht, Koningslaan 62, -------------------------------------------
-te dezen handelend als gevolmachtigde van te dezen handelend als   -
-gevolmachtigde van de vereniging Faculteitsvereniging van ----------
-Utrechtse Filosofiestudenten (F.U.F.) met zetel te Utrecht, --------
-kantoorhoudende te 3512 BR Utrecht, Drift 21k.207, ingeschreven in -
-het handelsregister bij de Kamer van Koophandel onder nummer -------
-30173498 en als zodanig gemelde vereniging te dezen rechtsgeldig ---
-vertegenwoordigende; -----------------------------------------------
-hierna te noemen: 'de vereniging'. ---------------------------------
+oktober negentienhonderdvierentachtig, met kantooradres 3583 GP
+Utrecht, Koningslaan 62,
+te dezen handelend als gevolmachtigde van te dezen handelend als
+gevolmachtigde van de vereniging Faculteitsvereniging van
+Utrechtse Filosofiestudenten (F.U.F.) met zetel te Utrecht,
+kantoorhoudende te 3512 BR Utrecht, Drift 21k.207, ingeschreven in
+het handelsregister bij de Kamer van Koophandel onder nummer
+30173498 en als zodanig gemelde vereniging te dezen rechtsgeldig
+vertegenwoordigende;
+hierna te noemen: 'de vereniging'.
 De comparant, handelend als hiervoor omschreven, verklaart vooraf:
 a. De vereniging is opgericht bij akte op negen en twintig augustus
    negentienhonderd vijf en negentig verleden voor W.M. van
    Grafhorst, destijds notaris te Utrecht.
-b. Bij besluit genomen in de ledenvergadering gehouden op * is —
-   besloten de statuten te wijzigen, welk besluit blijkt uit de aan —
-   deze akte gehechte notulen van die vergadering. _
-c. Gemeld besluit voldoet aan de vereisten gesteld in de statuten —
-   van de vereniging omtrent het nemen van een dergelijk besluit. —
-d. De comparant is in haar hoedanigheid van gevolmachtigde van -
+b. Bij besluit genomen in de ledenvergadering gehouden op * is
+   besloten de statuten te wijzigen, welk besluit blijkt uit de aan
+   deze akte gehechte notulen van die vergadering.
+c. Gemeld besluit voldoet aan de vereisten gesteld in de statuten
+   van de vereniging omtrent het nemen van een dergelijk besluit.
+d. De comparant is in haar hoedanigheid van gevolmachtigde van
    het bestuur van de vereniging in gemelde vergadering
-   gemachtigd om de onderwerpelijke wijziging van de statuten te -
+   gemachtigd om de onderwerpelijke wijziging van de statuten te
    doen passeren en te tekenen.
-De comparant, handelend als gemeld, verklaart vervolgens dat de —
+De comparant, handelend als gemeld, verklaart vervolgens dat de
 statuten bij dezen algeheel worden gewijzigd als volgt:
 
 ARTIKEL 1
-De vereniging draagt de naam Faculteitsvereniging van Utrechtse —
+De vereniging draagt de naam Faculteitsvereniging van Utrechtse
 Filosofiestudenten (FUF). Zij heeft haar zetel in de gemeente Utrecht.
 
 ARTIKEL 2
@@ -45,96 +45,96 @@ Doel
 1. De vereniging heeft ten doel een platform te creëren om
    filosofiestudenten van academische stimulatie en sociale cohesie
    te voorzien.
-2. Ter verwezenlijking van dit doel beoogt de vereniging het ——
+2. Ter verwezenlijking van dit doel beoogt de vereniging het
    organiseren van onder meer:
    a. Regelmatige bijeenkomsten waar over een filosofisch
-      onderwerp kan worden gediscussieerd. _
+      onderwerp kan worden gediscussieerd.
    b. Symposia waar door een of meerdere gastsprekers een
-      filosofisch thema behandeld wordt. —__
-   c. Wetenschappelijke excursies naar een filosofisch instituut —
-      en/of filosofische congressen in binnen- of buitenland. ——
-   d. Overige gemeenschapsvormende activiteiten teneinde van —
-      academische stimulatie en onderlinge verbroedering zoals —
+      filosofisch thema behandeld wordt.
+   c. Wetenschappelijke excursies naar een filosofisch instituut
+      en/of filosofische congressen in binnen- of buitenland.
+   d. Overige gemeenschapsvormende activiteiten teneinde van
+      academische stimulatie en onderlinge verbroedering zoals
       die genoemd zijn in het huishoudelijk reglement
 
 ARTIKEL 3 Duur
 1. De vereniging is aangegaan voor onbepaalde tijd.
-2. Het verenigingsjaar valt samen met het academisch jaar dat ——
+2. Het verenigingsjaar valt samen met het academisch jaar dat
    wordt aangehouden door de Universiteit Utrecht.
 3. Het boekjaar loopt van een september tot een en dertig augustus.
 
 ARTIKEL 4 Lidmaatschap
 1. De vereniging kent gewone leden, ereleden en donateurs.
 2. Gewone leden zijn zij die als zodanig zijn toegelaten
-   overeenkomstig het in artikel 5 bepaalde. _
-3. Ereleden worden op voorstel van het bestuur door de algemene -
+   overeenkomstig het in artikel 5 bepaalde.
+3. Ereleden worden op voorstel van het bestuur door de algemene
    ledenvergadering benoemd.
 4. Donateurs zijn jaarlijks een minimale geldelijke donatie
    verschuldigd welke in het huishoudelijk reglement nader wordt
    bepaald. Zij ontvangen de jaarverslagen van de vereniging.
 
 ARTIKEL 5
-1. Als gewoon lid worden alle studenten toegelaten die zich voor —
+1. Als gewoon lid worden alle studenten toegelaten die zich voor
    het betreffende studiejaar hebben ingeschreven voor de
    opleiding wijsbegeerte of een andere studie met significant
    wijsgerige elementen als hoofd- of bijvakstudent bij de
-   Universiteit Utrecht, nadat zij zich schriftelijk bij het bestuur —
+   Universiteit Utrecht, nadat zij zich schriftelijk bij het bestuur
    hebben aangemeld.
 2. Het bestuur beslist over de toelating van studenten die niet
    onder de categorie van lid 1 vallen.
-3. Indien de aanmelding wordt afgewezen wordt daarvan aan de —
-   aanmelder schriftelijk mededeling gedaan met vermelding van —
+3. Indien de aanmelding wordt afgewezen wordt daarvan aan de
+   aanmelder schriftelijk mededeling gedaan met vermelding van
    de reden(en) van de afwijzing. Na ontvangst van deze
    mededeling staat aan de afgewezene beroep open bij de
    eerstvolgende algemene ledenvergadering. De afgewezene dient
-   zijn of haar voornemen daartoe binnen een maand na ontvangst -
+   zijn of haar voornemen daartoe binnen een maand na ontvangst
    van voornoemde mededeling aan het bestuur kenbaar te maken.
-   In vervolg op dit beroep kan de algemene ledenvergadering ——
+   In vervolg op dit beroep kan de algemene ledenvergadering
    alsnog tot toelating besluiten.
-4. Het lidmaatschap is persoonlijk en mitsdien niet overdraagbaar. -
-5. Gewone leden en ereleden hebben een voorrangsrecht op het —
+4. Het lidmaatschap is persoonlijk en mitsdien niet overdraagbaar.
+5. Gewone leden en ereleden hebben een voorrangsrecht op het
    bijwonen van door de vereniging georganiseerde bijeenkomsten.
 
 ARTIKEL 6
-Het bestuur is bevoegd een lid te schorsen voor een periode van ten -
-hoogste één maand, in geval het lid bij herhaling in strijd handelt —
+Het bestuur is bevoegd een lid te schorsen voor een periode van ten
+hoogste één maand, in geval het lid bij herhaling in strijd handelt
 met zijn of haar lidmaatschapsverplichtingen of door handelingen of
-gedragingen het belang van de vereniging ernstig heeft geschaad. —
-Gedurende de periode dat een lid is geschorst, kunnen de aan het —
+gedragingen het belang van de vereniging ernstig heeft geschaad.
+Gedurende de periode dat een lid is geschorst, kunnen de aan het
 lidmaatschap verbonden rechten niet worden uitgeoefend.
 
 ARTIKEL 7
 1. Het lidmaatschap eindigt:
-   a. Door overlijden van het lid. Is een rechtspersoon lid van de —
+   a. Door overlijden van het lid. Is een rechtspersoon lid van de
    vereniging dan eindigt haar lidmaatschap wanneer zij
    ophoudt te bestaan;
    b. Door opzegging door het lid;
    c. Door opzegging namens de vereniging;
    d. Ontzetting.
 2. Opzegging van het lidmaatschap door het lid kan slechts
-   geschieden door een schriftelijke kennisgeving, welke voor de —
-   eerste september in het bezit van de secretaris moet zijn. Deze is -
+   geschieden door een schriftelijke kennisgeving, welke voor de
+   eerste september in het bezit van de secretaris moet zijn. Deze is
    verplicht de ontvangst binnen acht dagen schriftelijk te
-   bevestigen. Indien een opzegging niet tijdig plaats heeft gehad, —
-   loopt het lidmaatschap door tot het einde van het eerstvolgende -
-   verenigingsjaar, tenzij het bestuur anders besluit, of van het lid —
+   bevestigen. Indien een opzegging niet tijdig plaats heeft gehad,
+   loopt het lidmaatschap door tot het einde van het eerstvolgende
+   verenigingsjaar, tenzij het bestuur anders besluit, of van het lid
    redelijkerwijs niet gevergd kan worden het lidmaatschap te laten
    voortduren.
-3. Opzegging van het lidmaatschap namens de vereniging kan ——
+3. Opzegging van het lidmaatschap namens de vereniging kan
    tegen het einde van het lopende verenigingsjaar geschieden door
-   het bestuur met inachtneming van een opzeggingstermijn van —
-   tenminste vier weken, wanneer het lid, na daartoe bij herhaling —
-   schriftelijk te zijn aangemaand, op de eerste augustus niet ten —
-   volle aan zijn of haar verplichtingen jegens de vereniging heeft —
-   voldaan, alsmede wanneer het lid heeft opgehouden te voldoen -
-   aan de vereisten welke te eniger tijd door de statuten voor het —
-   lidmaatschap gesteld mochten worden. De opzegging door het —
-   bestuur kan onmiddellijk beëindiging van het lidmaatschap tot —
-   gevolg hebben, wanneer redelijkerwijs van de vereniging niet —
-   gevergd kan worden het lidmaatschap voort te laten duren. De —
+   het bestuur met inachtneming van een opzeggingstermijn van
+   tenminste vier weken, wanneer het lid, na daartoe bij herhaling
+   schriftelijk te zijn aangemaand, op de eerste augustus niet ten
+   volle aan zijn of haar verplichtingen jegens de vereniging heeft
+   voldaan, alsmede wanneer het lid heeft opgehouden te voldoen
+   aan de vereisten welke te eniger tijd door de statuten voor het
+   lidmaatschap gesteld mochten worden. De opzegging door het
+   bestuur kan onmiddellijk beëindiging van het lidmaatschap tot
+   gevolg hebben, wanneer redelijkerwijs van de vereniging niet
+   gevergd kan worden het lidmaatschap voort te laten duren. De
    opzegging geschiedt steeds schriftelijk met opgave van
    reden(en). Het bestuur behoudt het recht om namens de
-   vereniging een lid volgens de hierboven omschreven procedure -
+   vereniging een lid volgens de hierboven omschreven procedure
    uit te schrijven dat reeds een jaar of langer niet meer als hoofd- of
    bijvakstudent staat ingeschreven voor de opleiding wijsbegeerte
    of een andere studie met significant wijsgerige elementen bij de
@@ -143,58 +143,54 @@ ARTIKEL 7
 4. Ontzetting uit het lidmaatschap kan alleen worden uitgesproken
    wanneer een lid in strijd met de statuten, reglementen of
    besluiten van de vereniging handelt of de vereniging op
-   onredelijke wijze benadeelt. De ontzetting geschiedt door het —
-   bestuur, dat het lid ten spoedigste van het besluit, met opgave —
+   onredelijke wijze benadeelt. De ontzetting geschiedt door het
+   bestuur, dat het lid ten spoedigste van het besluit, met opgave
    van reden(en), in kennis stelt.
-   De betrokkene is bevoegd binnen een maand na ontvangst van —
+   De betrokkene is bevoegd binnen een maand na ontvangst van
    de kennisneming in beroep gaan bij de algemene
-   ledenvergadering. Gedurende de beroepstermijn en hangende —
+   ledenvergadering. Gedurende de beroepstermijn en hangende
    het beroep is het lid geschorst. Het besluit der algemene
-   vergadering tot ontzetting zal moeten worden genomen met ——
+   vergadering tot ontzetting zal moeten worden genomen met
    tenminste twee derden van het aantal geldig uitgebrachte
    stemmen.
-5. Wanneer het lidmaatschap in de loop van een verenigingsjaar, —
+5. Wanneer het lidmaatschap in de loop van een verenigingsjaar,
    ongeacht de reden of oorzaak, eindigt, blijft desondanks de
    eventuele jaarlijkse bijdrage voor het geheel door het lid
    verschuldigd, tenzij het bestuur anders besluit.
-6. In afwijking van het bepaalde in de eerste volzin van artikel 36 —
-   lid 3 van boek 2 BW kan een lid zich door opzegging van zijn of -
-   haar lidmaatschap niet onttrekken aan een besluit krachtens ——
-   hetwelk de verplichtingen van geldelijke aard van de leden ——
+6. In afwijking van het bepaalde in de eerste volzin van artikel 36
+   lid 3 van boek 2 BW kan een lid zich door opzegging van zijn of
+   haar lidmaatschap niet onttrekken aan een besluit krachtens
+   hetwelk de verplichtingen van geldelijke aard van de leden
    worden bezwaard, behoudens uiteraard het in lid 2 van dit
    artikel bepaalde.
 
 ARTIKEL 8 Geldmiddelen
 1. De geldmiddelen der vereniging bestaan uit de contributies van
-   de daartoe verplichte leden, uit de jaarlijkse subsidie van de het -
+   de daartoe verplichte leden, uit de jaarlijkse subsidie van de het
    departement filosofie en religiewetenschap van de faculteit
    geesteswetenschappen, uit entreegelden voor zover geheven, uit
    eventuele verkrijging ingevolge erfstellingen, legaten en
-   schenkingen, en ten slotte uit eventuele andere toevallige baten. -
+   schenkingen, en ten slotte uit eventuele andere toevallige baten.
 2. De hoogte van het bedrag van contributie voor de daartoe verplichte leden
    wordt jaarlijks door de algemene ledenvergadering tijdens de jaarvergadering
    vastgesteld.
-van hun taken worden deze commissies gedechargeerd. ————
-Wanneer de commissie niet ten volle aan haar verplichtingen —
-jegens de vereniging voldoet, heeft het bestuur de bevoegdheid -
-de commissie te dechargeren. _
 
 ARTIKEL 9 Bestuur-
-1. Het bestuur bestaat uit tenminste twee personen. Het aantal ——
-   bestuurders wordt vastgesteld door de algemene vergadering. —
-2. De bestuurders worden door de algemene vergadering uit de —
+1. Het bestuur bestaat uit tenminste twee personen. Het aantal
+   bestuurders wordt vastgesteld door de algemene vergadering.
+2. De bestuurders worden door de algemene vergadering uit de
    leden der vereniging benoemd, met dien verstande dat de
-   voorzitter door de algemene vergadering kan worden benoemd -
+   voorzitter door de algemene vergadering kan worden benoemd
    buiten de leden. Het bestuur wijst uit zijn midden een
-   penningmeester aan, en een secretaris. Alleen de functie van ——
+   penningmeester aan, en een secretaris. Alleen de functie van
    voorzitter kan met de functie van secretaris worden
-   gecombineerd. De voorzitter wordt steeds als zodanig door de —
+   gecombineerd. De voorzitter wordt steeds als zodanig door de
    algemene vergadering benoemd.
 3. De algemene vergadering kan een bestuurslid schorsen of
    ontslaan, indien zij daartoe termen aanwezig acht. Voor een
-   besluit daartoe is een meerderheid vereist van tenminste twee —
-   derden der geldig uitgebracht stemmen. —_
-4. De bestuursleden zijn bevoegd te allen tijde zelf hun ontslag te —
+   besluit daartoe is een meerderheid vereist van tenminste twee
+   derden der geldig uitgebracht stemmen.
+4. De bestuursleden zijn bevoegd te allen tijde zelf hun ontslag te
    nemen, mits dit schriftelijk geschiedt met een opzeggingstermijn
    van tenminste drie maanden.
 5. De bestuurders worden benoemd voor de duur van een
@@ -203,62 +199,66 @@ ARTIKEL 9 Bestuur-
 ARTIKEL 10
 1. Het bestuur is belast met het besturen der vereniging. Alle
    bestuurders gezamenlijk alsmede de voorzitter en de
-   penningmeester gezamenlijk zijn bevoegd de vereniging in en —
+   penningmeester gezamenlijk zijn bevoegd de vereniging in en
    buiten rechte te vertegenwoordigen. De bestuurders kunnen zich
    daarbij door een schriftelijk gemachtigde doen
    vertegenwoordigen.
 2. Voor het beschikken over bank- en giro saldi is een besluit
    dienaangaande van het bestuur vereist. Voorts is de
-   handtekening van de voorzitter of penningmeester voldoende. —
-3. Voor het aangaan van geldleningen, alsmede voor het kopen, —
-   vervreemden, bezwaren, huren of verhuren van onroerende — _
-   goederen, voor overeenkomsten waarbij de vereniging zich als —
+   handtekening van de voorzitter of penningmeester voldoende.
+3. Voor het aangaan van geldleningen, alsmede voor het kopen,
+   vervreemden, bezwaren, huren of verhuren van onroerende
+   goederen, voor overeenkomsten waarbij de vereniging zich als
    borg of hoofdelijk aansprakelijk medeschuldenaar verbindt, zich
-   voor een derde sterk maakt of zich tot zekerheidstelling voor de -
+   voor een derde sterk maakt of zich tot zekerheidstelling voor de
    schuld van een derde verbindt, behoeft het bestuur goedkeuring
-   van de algemene vergadering. Het bestuur is bevoegd om voor —
+   van de algemene vergadering. Het bestuur is bevoegd om voor
    de activiteiten waarnaar wordt verwezen in artikel 2 lid 2
    voorzieningen te treffen.
 4. Het bestuur is bevoegd om voor het realiseren van de
    doelstellingen van de vereniging, ad hoc commissies met
    beperkte taken en bevoegdheden in te stellen. Na het volbrengen
+van hun taken worden deze commissies gedechargeerd.
+Wanneer de commissie niet ten volle aan haar verplichtingen
+jegens de vereniging voldoet, heeft het bestuur de bevoegdheid
+de commissie te dechargeren.
 
-ARTIKEL 11 -
+ARTIKEL 11
 Algemene Vergaderingen
 1. Binnen zes maanden na afloop van elk boekjaar wordt een
    algemene vergadering (jaarvergadering) gehouden. Het bestuur
-   brengt in deze vergadering zijn jaarverslag uit en doet, onder —
+   brengt in deze vergadering zijn jaarverslag uit en doet, onder
    overlegging van de nodige bescheiden, rekening en
-   verantwoording van zijn in het afgelopen boekjaar gevoerd ——
+   verantwoording van zijn in het afgelopen boekjaar gevoerd
    bestuur.
-2. Het bestuur is verplicht aan de algemene vergadering alle door -
-   haar gewenste inlichtingen te verschaffen, haar desgewenst de —
+2. Het bestuur is verplicht aan de algemene vergadering alle door
+   haar gewenste inlichtingen te verschaffen, haar desgewenst de
    kas en de waarden der vereniging te tonen en inzage van boeken
-   en bescheiden der vereniging te geven. __
+   en bescheiden der vereniging te geven.
 3. Goedkeuring door de algemene vergadering van het jaarverslag
    en de rekening en verantwoording strekt het bestuur tot
    decharge.
 
 ARTIKEL 12
-1. De algemene ledenvergadering wordt bijeengeroepen door het —
+1. De algemene ledenvergadering wordt bijeengeroepen door het
    bestuur, met inachtneming van een termijn van 8 dagen. De
    bijeenroeping geschiedt door een aan alle leden te zenden
    schriftelijke mededeling. Behalve de in artikel 11 bedoelde
    jaarvergadering zullen algemene vergaderingen worden
-   gehouden zo dikwijls het bestuur zulks wenselijk acht, alsmede -
-   zo dikwijls zulks schriftelijk met opgave van de te behandelen —
+   gehouden zo dikwijls het bestuur zulks wenselijk acht, alsmede
+   zo dikwijls zulks schriftelijk met opgave van de te behandelen
    onderwerpen wordt verzocht door tenminste een zodanig aantal
-   leden als bevoegd is tot het uitbrengen van een tiende gedeelte —
-   der stemmen in de algemene vergadering, indien daarin alle —
-   leden tegenwoordig of vertegenwoordigd zijn _
+   leden als bevoegd is tot het uitbrengen van een tiende gedeelte
+   der stemmen in de algemene vergadering, indien daarin alle
+   leden tegenwoordig of vertegenwoordigd zijn
 
 2. Na ontvangst van een verzoek als in lid 1 bedoeld is het bestuur
    verplicht tot bijeenroepen van ener algemene vergadering op een
    termijn van niet lager dan vier weken. Indien aan het verzoek tot
-   bijeenroeping binnen veertien dagen nadat dit door het bestuur -
+   bijeenroeping binnen veertien dagen nadat dit door het bestuur
    werd ontvangen, geen gevolg wordt gegeven, zullen de
-   verzoekers zelf tot die bijeenroeping kunnen overgaan op de ——
-   wijze waarop het bestuur de algemene vergadering bijeenroept. -
+   verzoekers zelf tot die bijeenroeping kunnen overgaan op de
+   wijze waarop het bestuur de algemene vergadering bijeenroept.
 
 ARTIKEL 13
 1. Alle gewone leden hebben toegang tot de algemene vergadering
@@ -269,63 +269,63 @@ ARTIKEL 13
    statuten niet anders bepalen. Bij staking van stemmen wordt het
    voorstel geacht te zijn verworpen. Bij stemming over personen is
    hij of zij gekozen, die de volstrekte meerderheid der uitgebrachte
-   stemmen op zich heeft verenigd. Onder stemmen wordt in dit —
+   stemmen op zich heeft verenigd. Onder stemmen wordt in dit
    artikel verstaan geldig uitgebrachte stemmen, zodat niet in
    aanmerking komen blanco en met de naam van het lid
-   ondertekende stemmen. Een ter vergadering door de voorzitter -
-   uitgeroepen oordeel dat een besluit is genomen is beslissend. ——
-   Indien echter onmiddellijk na het uitspreken van dit oordeel de -
-   juistheid daarvan wordt betwist, vindt een nieuwe stemming —
-   plaats wanneer de meerderheid der vergadering of, indien de —
+   ondertekende stemmen. Een ter vergadering door de voorzitter
+   uitgeroepen oordeel dat een besluit is genomen is beslissend.
+   Indien echter onmiddellijk na het uitspreken van dit oordeel de
+   juistheid daarvan wordt betwist, vindt een nieuwe stemming
+   plaats wanneer de meerderheid der vergadering of, indien de
    oorspronkelijke stemming niet hoofdelijk of schriftelijk
    geschiedde, een stemgerechtigde aanwezige dit verlangt.
 
 ARTIKEL 14
-1. De voorzitter van het bestuur leidt de vergadering. Bij zijn of ——
+1. De voorzitter van het bestuur leidt de vergadering. Bij zijn of
    haar afwezigheid of ontstentenis zal een der andere
-   bestuursleden als leider der vergadering optreden. Van het ter —
+   bestuursleden als leider der vergadering optreden. Van het ter
    algemene vergadering verhandelde worden door de secretaris of
-   een door de voorzitter aangewezen lid der vereniging notulen —
+   een door de voorzitter aangewezen lid der vereniging notulen
    gehouden.
 2. In het geval dat een algemene ledenvergadering bijeen is
-   geroepen door een tiende van het totale aantal stemgerechtigde -
-   leden bepaalt deze fractie wie de vergadering zal leiden. Als het -
+   geroepen door een tiende van het totale aantal stemgerechtigde
+   leden bepaalt deze fractie wie de vergadering zal leiden. Als het
    verkozen lid niet de voorzitter van het bestuur is maar de
    voorzitter wel aanwezig is mag de voorzitter een stemming
    eisen, en met een volstrekte meerderheid der stemmen van de op
-   de vergadering aanwezige leden alsnog de vergadering leiden.—
+   de vergadering aanwezige leden alsnog de vergadering leiden.
 
 ARTIKEL 15
 1. Wijziging van de statuten kan slechts plaats hebben na een
    besluit van de algemene vergadering, waartoe werd opgeroepen
-   met de mededeling daarin dat wijziging van de statuten zal ——
+   met de mededeling daarin dat wijziging van de statuten zal
    worden voorgesteld. De termijn voor oproeping tot een zodanige
    vergadering moet tenminste veertien dagen bedragen.
 2. Zij, die de oproeping tot de algemene vergadering ter
    behandeling van een voorstel tot statutenwijziging hebben
    gedaan, moeten tenminste vijf dagen voor de dag der
    vergadering een afschrift van dat voorstel, waarin de
-   voorgestelde wijziging(en) woordelijk is (zijn) opgenomen, op —
-   een daartoe geschikte plaats voor de leden ter inzage leggen tot -
+   voorgestelde wijziging(en) woordelijk is (zijn) opgenomen, op
+   een daartoe geschikte plaats voor de leden ter inzage leggen tot
    na de dag, waarop de vergadering werd gehouden.
-3. Tot wijziging van de statuten kan slechts besloten worden door -
-   een algemene vergadering waar tenminste twee derden van het -
+3. Tot wijziging van de statuten kan slechts besloten worden door
+   een algemene vergadering waar tenminste twee derden van het
    totaal aantal leden der vereniging aanwezig of
-   vertegenwoordigd is, met een meerderheid van tenminste twee -
-   derde van het aantal uitgebrachte stemmen. —__
-4. Bij gebreke van het quorum kan ongeacht het aantal ter ———
+   vertegenwoordigd is, met een meerderheid van tenminste twee
+   derde van het aantal uitgebrachte stemmen.
+4. Bij gebreke van het quorum kan ongeacht het aantal ter
    vergadering aanwezige of vertegenwoordigde leden tot
    wijziging van de statuten worden besloten op een volgende,
    tenminste acht dagen doch uiterlijk dertig dagen na de eerste, te
-   houden vergadering, met een meerderheid van tenminste twee —
-   derden van de uitgebrachte stemmen. Tenminste acht dagen —
-   voor deze te houden tweede vergadering moet aan alle leden —
-   worden medegedeeld dat over het wijzigen van de statuten zal —
+   houden vergadering, met een meerderheid van tenminste twee
+   derden van de uitgebrachte stemmen. Tenminste acht dagen
+   voor deze te houden tweede vergadering moet aan alle leden
+   worden medegedeeld dat over het wijzigen van de statuten zal
    worden besloten.
 
 ARTIKEL 16
 Het in artikel 15 bepaalde is niet van toepassing indien ter algemene
-vergadering alle leden aanwezig of vertegenwoordigd zijn en het —
+vergadering alle leden aanwezig of vertegenwoordigd zijn en het
 besluit tot statutenwijzigingen met algemene stemmen wordt
 genomen.
 
@@ -336,29 +336,29 @@ gewijzigd met inachtneming van gelijke beperking.
 
 ARTIKEL 18 Ontbinden en Vereffening
 1. Behoudens het bepaalde in artikel 50 van Boek 2 van het
-   Burgerlijk Wetboek wordt de vereniging ontbonden door een —
-   besluit daartoe van de algemene vergadering genomen met ——
+   Burgerlijk Wetboek wordt de vereniging ontbonden door een
+   besluit daartoe van de algemene vergadering genomen met
    tenminste twee derden van het aantal geldig uitgebrachte
-   stemmen in een vergadering waarin tenminste drie vierden van -
-   het aantal leden aanwezig of vertegenwoordigd is.———
-2. Bij gebreke van het quorum kan ongeacht het aantal ter ———
+   stemmen in een vergadering waarin tenminste drie vierden van
+   het aantal leden aanwezig of vertegenwoordigd is.
+2. Bij gebreke van het quorum kan ongeacht het aantal ter
    vergadering aanwezige of vertegenwoordigde leden tot
-   ontbinding worden besloten op een volgende, tenminste acht —
+   ontbinding worden besloten op een volgende, tenminste acht
    dagen doch uiterlijk dertig dagen na de eerste, te houden
-   vergadering, met een meerderheid van tenminste twee derden —
-   van de uitgebrachte stemmen. Tenminste acht dagen voor deze -
+   vergadering, met een meerderheid van tenminste twee derden
+   van de uitgebrachte stemmen. Tenminste acht dagen voor deze
    te houden tweede vergadering moet aan alle leden worden
    medegedeeld dat over de ontbinding van de vereniging zal
    worden besloten.
 3. Bij de oproeping tot de in de leden 1 en 2 van dit artikel bedoelde
-   vergaderingen moet worden medegedeeld dat ter vergadering —
+   vergaderingen moet worden medegedeeld dat ter vergadering
    zal worden voorgesteld de vereniging te ontbinden. De termijn
-   voor oproeping tot zodanige vergaderingen moet tenminste ——
+   voor oproeping tot zodanige vergaderingen moet tenminste
    veertien dagen bedragen.
 4. Indien bij een besluit tot ontbinding te dien aanzien geen
    vereffenaars zijn aangewezen, geschiedt de vereffening door het
    bestuur.
-5. Indien de Algemene Ledenvergadering besluit tot ontbinding —
+5. Indien de Algemene Ledenvergadering besluit tot ontbinding
    wordt tevens de bestemming van het liquidatiesaldo vastgesteld.
    Het liquidatiesaldo dient te worden besteed ten behoeve van een
    Algemeen Nut Beogende Instelling met een soortgelijke
@@ -366,27 +366,27 @@ ARTIKEL 18 Ontbinden en Vereffening
 
 ARTIKEL 19
 1. De algemene vergadering kan bij huishoudelijk reglement
-   nadere regels geven omtrent het lidmaatschap, de introductie, —
+   nadere regels geven omtrent het lidmaatschap, de introductie,
    het bedrag der contributies en entreegelden, de werkzaamheden
    van het bestuur, de vergaderingen, de wijze van uitoefening van
    het stemrecht, het beheer en gebruik van het gebouw der
-   vereniging en alle verdere onderwerpen waarvan de regeling —
+   vereniging en alle verdere onderwerpen waarvan de regeling
    haar gewenst voorkomt.
 2. Wijziging van het huishoudelijk reglement kan slechts
    geschieden bij besluit van de algemene vergadering.
 3. Het huishoudelijk reglement zal geen bepalingen mogen
    bevatten die afwijken van of die strijd zijn met de bepalingen van
-   de wet of van de statuten, tenzij de afwijking door de wet of de —
+   de wet of van de statuten, tenzij de afwijking door de wet of de
    statuten wordt toegestaan.
 De comparant is mij, notaris, bekend.
-WAARVAN AKTE is verleden te Utrecht op de datum in het hoofd -
-van deze akte vermeld. De zakelijke inhoud van de akte is aan de —
-comparant opgegeven en toegelicht. De comparant heeft verklaard —
-op volledige voorlezing van de akte geen prijs te stellen, tijdig voor —
-het verlijden van de inhoud van de akte te hebben kennis genomen —
+WAARVAN AKTE is verleden te Utrecht op de datum in het hoofd
+van deze akte vermeld. De zakelijke inhoud van de akte is aan de
+comparant opgegeven en toegelicht. De comparant heeft verklaard
+op volledige voorlezing van de akte geen prijs te stellen, tijdig voor
+het verlijden van de inhoud van de akte te hebben kennis genomen
 en met de inhoud in te stemmen.
 Deze akte is beperkt voorgelezen en onmiddellijk daarna
-ondertekend, eerst door de comparant en vervolgens door mij, ——
+ondertekend, eerst door de comparant en vervolgens door mij,
 notaris.
 (Volgt ondertekening).
 

--- a/statuten.txt
+++ b/statuten.txt
@@ -1,0 +1,397 @@
+Holtman notarissen - 1 -
+
+865454 /me
+21-07-2017
+
+          STATUTENWIJZIGING VERENIGING
+
+Heden, een en twintig juli tweeduizend zeventien, ------------------
+verscheen voor mij, mr. Madeline Elisabeth Westers-Koopmans, -------
+kandidaat-notaris, hierna te noemen "notaris", vaste waarnemer van -
+mr. Ritzo Jacob Holtman, notaris te Utrecht: ----------------------
+mevrouw Samantha Subadra de Jong, geboren te Ratnapura op twee
+oktober negentienhonderdvierentachtig, met kantooradres 3583 GP    -
+Utrecht, Koningslaan 62, -------------------------------------------
+te dezen handelend als gevolmachtigde van te dezen handelend als   -
+gevolmachtigde van de vereniging Faculteitsvereniging van ----------
+Utrechtse Filosofiestudenten (F.U.F.) met zetel te Utrecht, --------
+kantoorhoudende te 3512 BR Utrecht, Drift 21k.207, ingeschreven in -
+het handelsregister bij de Kamer van Koophandel onder nummer -------
+30173498 en als zodanig gemelde vereniging te dezen rechtsgeldig ---
+vertegenwoordigende; -----------------------------------------------
+hierna te noemen: 'de vereniging'. ---------------------------------
+De comparant, handelend als hiervoor omschreven, verklaart vooraf:
+a. De vereniging is opgericht bij akte op negen en twintig augustus
+   negentienhonderd vijf en negentig verleden voor W.M. van
+   Grafhorst, destijds notaris te Utrecht.
+b. Bij besluit genomen in de ledenvergadering gehouden op * is —
+   besloten de statuten te wijzigen, welk besluit blijkt uit de aan —
+   deze akte gehechte notulen van die vergadering. _
+c. Gemeld besluit voldoet aan de vereisten gesteld in de statuten —
+   van de vereniging omtrent het nemen van een dergelijk besluit. —
+d. De comparant is in haar hoedanigheid van gevolmachtigde van -
+   het bestuur van de vereniging in gemelde vergadering
+   gemachtigd om de onderwerpelijke wijziging van de statuten te -
+   doen passeren en te tekenen.
+De comparant, handelend als gemeld, verklaart vervolgens dat de —
+statuten bij dezen algeheel worden gewijzigd als volgt:
+
+ARTIKEL 1
+De vereniging draagt de naam Faculteitsvereniging van Utrechtse —
+Filosofiestudenten (FUF). Zij heeft haar zetel in de gemeente Utrecht.
+
+ARTIKEL 2
+Doel
+1. De vereniging heeft ten doel een platform te creëren om
+   filosofiestudenten van academische stimulatie en sociale cohesie
+   te voorzien.
+2. Ter verwezenlijking van dit doel beoogt de vereniging het ——
+   organiseren van onder meer:
+   a. Regelmatige bijeenkomsten waar over een filosofisch
+      onderwerp kan worden gediscussieerd. _
+   b. Symposia waar door een of meerdere gastsprekers een
+      filosofisch thema behandeld wordt. —__
+   c. Wetenschappelijke excursies naar een filosofisch instituut —
+      en/of filosofische congressen in binnen- of buitenland. ——
+   d. Overige gemeenschapsvormende activiteiten teneinde van —
+      academische stimulatie en onderlinge verbroedering zoals —
+      die genoemd zijn in het huishoudelijk reglement
+
+ARTIKEL 3 Duur
+1. De vereniging is aangegaan voor onbepaalde tijd.
+2. Het verenigingsjaar valt samen met het academisch jaar dat ——
+   wordt aangehouden door de Universiteit Utrecht.
+3. Het boekjaar loopt van een september tot een en dertig augustus.
+
+ARTIKEL 4 Lidmaatschap
+1. De vereniging kent gewone leden, ereleden en donateurs.
+2. Gewone leden zijn zij die als zodanig zijn toegelaten
+   overeenkomstig het in artikel 5 bepaalde. _
+3. Ereleden worden op voorstel van het bestuur door de algemene -
+   ledenvergadering benoemd.
+4. Donateurs zijn jaarlijks een minimale geldelijke donatie
+   verschuldigd welke in het huishoudelijk reglement nader wordt
+   bepaald. Zij ontvangen de jaarverslagen van de vereniging.
+
+ARTIKEL 5
+1. Als gewoon lid worden alle studenten toegelaten die zich voor —
+   het betreffende studiejaar hebben ingeschreven voor de
+   opleiding wijsbegeerte of een andere studie met significant
+   wijsgerige elementen als hoofd- of bijvakstudent bij de
+   Universiteit Utrecht, nadat zij zich schriftelijk bij het bestuur —
+   hebben aangemeld.
+2. Het bestuur beslist over de toelating van studenten die niet
+   onder de categorie van lid 1 vallen.
+3. Indien de aanmelding wordt afgewezen wordt daarvan aan de —
+   aanmelder schriftelijk mededeling gedaan met vermelding van —
+   de reden(en) van de afwijzing. Na ontvangst van deze
+   mededeling staat aan de afgewezene beroep open bij de
+   eerstvolgende algemene ledenvergadering. De afgewezene dient
+   zijn of haar voornemen daartoe binnen een maand na ontvangst -
+   van voornoemde mededeling aan het bestuur kenbaar te maken.
+   In vervolg op dit beroep kan de algemene ledenvergadering ——
+   alsnog tot toelating besluiten.
+4. Het lidmaatschap is persoonlijk en mitsdien niet overdraagbaar. -
+5. Gewone leden en ereleden hebben een voorrangsrecht op het —
+   bijwonen van door de vereniging georganiseerde bijeenkomsten.
+
+ARTIKEL 6
+Het bestuur is bevoegd een lid te schorsen voor een periode van ten -
+hoogste één maand, in geval het lid bij herhaling in strijd handelt —
+met zijn of haar lidmaatschapsverplichtingen of door handelingen of
+gedragingen het belang van de vereniging ernstig heeft geschaad. —
+Gedurende de periode dat een lid is geschorst, kunnen de aan het —
+lidmaatschap verbonden rechten niet worden uitgeoefend.
+
+ARTIKEL 7
+1. Het lidmaatschap eindigt:
+   a. Door overlijden van het lid. Is een rechtspersoon lid van de —
+   vereniging dan eindigt haar lidmaatschap wanneer zij
+   ophoudt te bestaan;
+   b. Door opzegging door het lid;
+   c. Door opzegging namens de vereniging;
+   d. Ontzetting.
+2. Opzegging van het lidmaatschap door het lid kan slechts
+   geschieden door een schriftelijke kennisgeving, welke voor de —
+   eerste september in het bezit van de secretaris moet zijn. Deze is -
+   verplicht de ontvangst binnen acht dagen schriftelijk te
+   bevestigen. Indien een opzegging niet tijdig plaats heeft gehad, —
+   loopt het lidmaatschap door tot het einde van het eerstvolgende -
+   verenigingsjaar, tenzij het bestuur anders besluit, of van het lid —
+   redelijkerwijs niet gevergd kan worden het lidmaatschap te laten
+   voortduren.
+3. Opzegging van het lidmaatschap namens de vereniging kan ——
+   tegen het einde van het lopende verenigingsjaar geschieden door
+   het bestuur met inachtneming van een opzeggingstermijn van —
+   tenminste vier weken, wanneer het lid, na daartoe bij herhaling —
+   schriftelijk te zijn aangemaand, op de eerste augustus niet ten —
+   volle aan zijn of haar verplichtingen jegens de vereniging heeft —
+   voldaan, alsmede wanneer het lid heeft opgehouden te voldoen -
+   aan de vereisten welke te eniger tijd door de statuten voor het —
+   lidmaatschap gesteld mochten worden. De opzegging door het —
+   bestuur kan onmiddellijk beëindiging van het lidmaatschap tot —
+   gevolg hebben, wanneer redelijkerwijs van de vereniging niet —
+   gevergd kan worden het lidmaatschap voort te laten duren. De —
+   opzegging geschiedt steeds schriftelijk met opgave van
+   reden(en). Het bestuur behoudt het recht om namens de
+   vereniging een lid volgens de hierboven omschreven procedure -
+   uit te schrijven dat reeds een jaar of langer niet meer als hoofd- of
+   bijvakstudent staat ingeschreven voor de opleiding wijsbegeerte
+   of een andere studie met significant wijsgerige elementen bij de
+   Universiteit Utrecht. In overleg met het lid kan het lidmaatschap
+   worden omgezet in een donateurschap.
+4. Ontzetting uit het lidmaatschap kan alleen worden uitgesproken
+   wanneer een lid in strijd met de statuten, reglementen of
+   besluiten van de vereniging handelt of de vereniging op
+   onredelijke wijze benadeelt. De ontzetting geschiedt door het —
+   bestuur, dat het lid ten spoedigste van het besluit, met opgave —
+   van reden(en), in kennis stelt.
+   De betrokkene is bevoegd binnen een maand na ontvangst van —
+   de kennisneming in beroep gaan bij de algemene
+   ledenvergadering. Gedurende de beroepstermijn en hangende —
+   het beroep is het lid geschorst. Het besluit der algemene
+   vergadering tot ontzetting zal moeten worden genomen met ——
+   tenminste twee derden van het aantal geldig uitgebrachte
+   stemmen.
+5. Wanneer het lidmaatschap in de loop van een verenigingsjaar, —
+   ongeacht de reden of oorzaak, eindigt, blijft desondanks de
+   eventuele jaarlijkse bijdrage voor het geheel door het lid
+   verschuldigd, tenzij het bestuur anders besluit.
+6. In afwijking van het bepaalde in de eerste volzin van artikel 36 —
+   lid 3 van boek 2 BW kan een lid zich door opzegging van zijn of -
+   haar lidmaatschap niet onttrekken aan een besluit krachtens ——
+   hetwelk de verplichtingen van geldelijke aard van de leden ——
+   worden bezwaard, behoudens uiteraard het in lid 2 van dit
+   artikel bepaalde.
+
+ARTIKEL 8 Geldmiddelen
+1. De geldmiddelen der vereniging bestaan uit de contributies van
+   de daartoe verplichte leden, uit de jaarlijkse subsidie van de het -
+   departement filosofie en religiewetenschap van de faculteit
+   geesteswetenschappen, uit entreegelden voor zover geheven, uit
+   eventuele verkrijging ingevolge erfstellingen, legaten en
+   schenkingen, en ten slotte uit eventuele andere toevallige baten. -
+2. De hoogte van het bedrag van contributie voor de daartoe verplichte leden
+   wordt jaarlijks door de algemene ledenvergadering tijdens de jaarvergadering
+   vastgesteld.
+van hun taken worden deze commissies gedechargeerd. ————
+Wanneer de commissie niet ten volle aan haar verplichtingen —
+jegens de vereniging voldoet, heeft het bestuur de bevoegdheid -
+de commissie te dechargeren. _
+
+ARTIKEL 9 Bestuur-
+1. Het bestuur bestaat uit tenminste twee personen. Het aantal ——
+   bestuurders wordt vastgesteld door de algemene vergadering. —
+2. De bestuurders worden door de algemene vergadering uit de —
+   leden der vereniging benoemd, met dien verstande dat de
+   voorzitter door de algemene vergadering kan worden benoemd -
+   buiten de leden. Het bestuur wijst uit zijn midden een
+   penningmeester aan, en een secretaris. Alleen de functie van ——
+   voorzitter kan met de functie van secretaris worden
+   gecombineerd. De voorzitter wordt steeds als zodanig door de —
+   algemene vergadering benoemd.
+3. De algemene vergadering kan een bestuurslid schorsen of
+   ontslaan, indien zij daartoe termen aanwezig acht. Voor een
+   besluit daartoe is een meerderheid vereist van tenminste twee —
+   derden der geldig uitgebracht stemmen. —_
+4. De bestuursleden zijn bevoegd te allen tijde zelf hun ontslag te —
+   nemen, mits dit schriftelijk geschiedt met een opzeggingstermijn
+   van tenminste drie maanden.
+5. De bestuurders worden benoemd voor de duur van een
+   verenigingsjaar.
+
+ARTIKEL 10
+1. Het bestuur is belast met het besturen der vereniging. Alle
+   bestuurders gezamenlijk alsmede de voorzitter en de
+   penningmeester gezamenlijk zijn bevoegd de vereniging in en —
+   buiten rechte te vertegenwoordigen. De bestuurders kunnen zich
+   daarbij door een schriftelijk gemachtigde doen
+   vertegenwoordigen.
+2. Voor het beschikken over bank- en giro saldi is een besluit
+   dienaangaande van het bestuur vereist. Voorts is de
+   handtekening van de voorzitter of penningmeester voldoende. —
+3. Voor het aangaan van geldleningen, alsmede voor het kopen, —
+   vervreemden, bezwaren, huren of verhuren van onroerende — _
+   goederen, voor overeenkomsten waarbij de vereniging zich als —
+   borg of hoofdelijk aansprakelijk medeschuldenaar verbindt, zich
+   voor een derde sterk maakt of zich tot zekerheidstelling voor de -
+   schuld van een derde verbindt, behoeft het bestuur goedkeuring
+   van de algemene vergadering. Het bestuur is bevoegd om voor —
+   de activiteiten waarnaar wordt verwezen in artikel 2 lid 2
+   voorzieningen te treffen.
+4. Het bestuur is bevoegd om voor het realiseren van de
+   doelstellingen van de vereniging, ad hoc commissies met
+   beperkte taken en bevoegdheden in te stellen. Na het volbrengen
+
+ARTIKEL 11 -
+Algemene Vergaderingen
+1. Binnen zes maanden na afloop van elk boekjaar wordt een
+   algemene vergadering (jaarvergadering) gehouden. Het bestuur
+   brengt in deze vergadering zijn jaarverslag uit en doet, onder —
+   overlegging van de nodige bescheiden, rekening en
+   verantwoording van zijn in het afgelopen boekjaar gevoerd ——
+   bestuur.
+2. Het bestuur is verplicht aan de algemene vergadering alle door -
+   haar gewenste inlichtingen te verschaffen, haar desgewenst de —
+   kas en de waarden der vereniging te tonen en inzage van boeken
+   en bescheiden der vereniging te geven. __
+3. Goedkeuring door de algemene vergadering van het jaarverslag
+   en de rekening en verantwoording strekt het bestuur tot
+   decharge.
+
+ARTIKEL 12
+1. De algemene ledenvergadering wordt bijeengeroepen door het —
+   bestuur, met inachtneming van een termijn van 8 dagen. De
+   bijeenroeping geschiedt door een aan alle leden te zenden
+   schriftelijke mededeling. Behalve de in artikel 11 bedoelde
+   jaarvergadering zullen algemene vergaderingen worden
+   gehouden zo dikwijls het bestuur zulks wenselijk acht, alsmede -
+   zo dikwijls zulks schriftelijk met opgave van de te behandelen —
+   onderwerpen wordt verzocht door tenminste een zodanig aantal
+   leden als bevoegd is tot het uitbrengen van een tiende gedeelte —
+   der stemmen in de algemene vergadering, indien daarin alle —
+   leden tegenwoordig of vertegenwoordigd zijn _
+
+2. Na ontvangst van een verzoek als in lid 1 bedoeld is het bestuur
+   verplicht tot bijeenroepen van ener algemene vergadering op een
+   termijn van niet lager dan vier weken. Indien aan het verzoek tot
+   bijeenroeping binnen veertien dagen nadat dit door het bestuur -
+   werd ontvangen, geen gevolg wordt gegeven, zullen de
+   verzoekers zelf tot die bijeenroeping kunnen overgaan op de ——
+   wijze waarop het bestuur de algemene vergadering bijeenroept. -
+
+ARTIKEL 13
+1. Alle gewone leden hebben toegang tot de algemene vergadering
+   en hebben daar ieder een stem.
+2. Stemming geschiedt mondeling of schriftelijk.
+3. Over alle voorstellen betreffende zaken wordt beslist bij
+   volstrekte meerderheid der uitgebrachte stemmen, voor zover de
+   statuten niet anders bepalen. Bij staking van stemmen wordt het
+   voorstel geacht te zijn verworpen. Bij stemming over personen is
+   hij of zij gekozen, die de volstrekte meerderheid der uitgebrachte
+   stemmen op zich heeft verenigd. Onder stemmen wordt in dit —
+   artikel verstaan geldig uitgebrachte stemmen, zodat niet in
+   aanmerking komen blanco en met de naam van het lid
+   ondertekende stemmen. Een ter vergadering door de voorzitter -
+   uitgeroepen oordeel dat een besluit is genomen is beslissend. ——
+   Indien echter onmiddellijk na het uitspreken van dit oordeel de -
+   juistheid daarvan wordt betwist, vindt een nieuwe stemming —
+   plaats wanneer de meerderheid der vergadering of, indien de —
+   oorspronkelijke stemming niet hoofdelijk of schriftelijk
+   geschiedde, een stemgerechtigde aanwezige dit verlangt.
+
+ARTIKEL 14
+1. De voorzitter van het bestuur leidt de vergadering. Bij zijn of ——
+   haar afwezigheid of ontstentenis zal een der andere
+   bestuursleden als leider der vergadering optreden. Van het ter —
+   algemene vergadering verhandelde worden door de secretaris of
+   een door de voorzitter aangewezen lid der vereniging notulen —
+   gehouden.
+2. In het geval dat een algemene ledenvergadering bijeen is
+   geroepen door een tiende van het totale aantal stemgerechtigde -
+   leden bepaalt deze fractie wie de vergadering zal leiden. Als het -
+   verkozen lid niet de voorzitter van het bestuur is maar de
+   voorzitter wel aanwezig is mag de voorzitter een stemming
+   eisen, en met een volstrekte meerderheid der stemmen van de op
+   de vergadering aanwezige leden alsnog de vergadering leiden.—
+
+ARTIKEL 15
+1. Wijziging van de statuten kan slechts plaats hebben na een
+   besluit van de algemene vergadering, waartoe werd opgeroepen
+   met de mededeling daarin dat wijziging van de statuten zal ——
+   worden voorgesteld. De termijn voor oproeping tot een zodanige
+   vergadering moet tenminste veertien dagen bedragen.
+2. Zij, die de oproeping tot de algemene vergadering ter
+   behandeling van een voorstel tot statutenwijziging hebben
+   gedaan, moeten tenminste vijf dagen voor de dag der
+   vergadering een afschrift van dat voorstel, waarin de
+   voorgestelde wijziging(en) woordelijk is (zijn) opgenomen, op —
+   een daartoe geschikte plaats voor de leden ter inzage leggen tot -
+   na de dag, waarop de vergadering werd gehouden.
+3. Tot wijziging van de statuten kan slechts besloten worden door -
+   een algemene vergadering waar tenminste twee derden van het -
+   totaal aantal leden der vereniging aanwezig of
+   vertegenwoordigd is, met een meerderheid van tenminste twee -
+   derde van het aantal uitgebrachte stemmen. —__
+4. Bij gebreke van het quorum kan ongeacht het aantal ter ———
+   vergadering aanwezige of vertegenwoordigde leden tot
+   wijziging van de statuten worden besloten op een volgende,
+   tenminste acht dagen doch uiterlijk dertig dagen na de eerste, te
+   houden vergadering, met een meerderheid van tenminste twee —
+   derden van de uitgebrachte stemmen. Tenminste acht dagen —
+   voor deze te houden tweede vergadering moet aan alle leden —
+   worden medegedeeld dat over het wijzigen van de statuten zal —
+   worden besloten.
+
+ARTIKEL 16
+Het in artikel 15 bepaalde is niet van toepassing indien ter algemene
+vergadering alle leden aanwezig of vertegenwoordigd zijn en het —
+besluit tot statutenwijzigingen met algemene stemmen wordt
+genomen.
+
+ARTIKEL 17
+Een bepaling dezer statuten, welke de bevoegdheid tot wijziging van
+een of meer andere bepalingen beperkt, kan slechts worden
+gewijzigd met inachtneming van gelijke beperking.
+
+ARTIKEL 18 Ontbinden en Vereffening
+1. Behoudens het bepaalde in artikel 50 van Boek 2 van het
+   Burgerlijk Wetboek wordt de vereniging ontbonden door een —
+   besluit daartoe van de algemene vergadering genomen met ——
+   tenminste twee derden van het aantal geldig uitgebrachte
+   stemmen in een vergadering waarin tenminste drie vierden van -
+   het aantal leden aanwezig of vertegenwoordigd is.———
+2. Bij gebreke van het quorum kan ongeacht het aantal ter ———
+   vergadering aanwezige of vertegenwoordigde leden tot
+   ontbinding worden besloten op een volgende, tenminste acht —
+   dagen doch uiterlijk dertig dagen na de eerste, te houden
+   vergadering, met een meerderheid van tenminste twee derden —
+   van de uitgebrachte stemmen. Tenminste acht dagen voor deze -
+   te houden tweede vergadering moet aan alle leden worden
+   medegedeeld dat over de ontbinding van de vereniging zal
+   worden besloten.
+3. Bij de oproeping tot de in de leden 1 en 2 van dit artikel bedoelde
+   vergaderingen moet worden medegedeeld dat ter vergadering —
+   zal worden voorgesteld de vereniging te ontbinden. De termijn
+   voor oproeping tot zodanige vergaderingen moet tenminste ——
+   veertien dagen bedragen.
+4. Indien bij een besluit tot ontbinding te dien aanzien geen
+   vereffenaars zijn aangewezen, geschiedt de vereffening door het
+   bestuur.
+5. Indien de Algemene Ledenvergadering besluit tot ontbinding —
+   wordt tevens de bestemming van het liquidatiesaldo vastgesteld.
+   Het liquidatiesaldo dient te worden besteed ten behoeve van een
+   Algemeen Nut Beogende Instelling met een soortgelijke
+   doelstelling.
+
+ARTIKEL 19
+1. De algemene vergadering kan bij huishoudelijk reglement
+   nadere regels geven omtrent het lidmaatschap, de introductie, —
+   het bedrag der contributies en entreegelden, de werkzaamheden
+   van het bestuur, de vergaderingen, de wijze van uitoefening van
+   het stemrecht, het beheer en gebruik van het gebouw der
+   vereniging en alle verdere onderwerpen waarvan de regeling —
+   haar gewenst voorkomt.
+2. Wijziging van het huishoudelijk reglement kan slechts
+   geschieden bij besluit van de algemene vergadering.
+3. Het huishoudelijk reglement zal geen bepalingen mogen
+   bevatten die afwijken van of die strijd zijn met de bepalingen van
+   de wet of van de statuten, tenzij de afwijking door de wet of de —
+   statuten wordt toegestaan.
+De comparant is mij, notaris, bekend.
+WAARVAN AKTE is verleden te Utrecht op de datum in het hoofd -
+van deze akte vermeld. De zakelijke inhoud van de akte is aan de —
+comparant opgegeven en toegelicht. De comparant heeft verklaard —
+op volledige voorlezing van de akte geen prijs te stellen, tijdig voor —
+het verlijden van de inhoud van de akte te hebben kennis genomen —
+en met de inhoud in te stemmen.
+Deze akte is beperkt voorgelezen en onmiddellijk daarna
+ondertekend, eerst door de comparant en vervolgens door mij, ——
+notaris.
+(Volgt ondertekening).
+
+                                          UITGEGEVEN VOOR AFSCHRIFT
+                                          door mij, mr. M.E. Westers-
+        <STEMPEL VAN MR R.J HOLTMAN       Koopmans, vaste waarnemer van
+             NOTARIS TE UTRECHT>          mr. Ritzo Jacob Holtman, notaris
+                                          te Utrecht


### PR DESCRIPTION
Ik denk dat deze versie van de statuten de adequaatste is om vanaf te gaan werken. Het is een vrij letterlijke vertaling van wat in het oude document staat. Per regel, maar zonder de '---' regels aan het einde van elke regel.
Dit zou als het goed is de betekenis van wat in het pdf staat moeten behouden. 